### PR TITLE
Fix: Automatically assign  role as ADMIN  for admin whenever admin si…

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -4,11 +4,24 @@ const {setUser,getUser}=require("../servers/auth.js")
 async function handleNewUser(req,res) {
     console.log(req.body);
     const {name,email,password}=req.body;
+    if(email=="dipteshpiku@gmail.com"){
     await USER.create({
+        
         name:name,
         email:email,
         password:password,
+        role:"ADMIN",
     })
+}
+    else{
+    await USER.create({
+        
+        name:name,
+        email:email,
+        password:password,
+        role:"NORMAL",
+    })
+}
     return res.redirect("/");
 }
 async function handleLoginUser(req,res) {

--- a/models/user.js
+++ b/models/user.js
@@ -14,7 +14,6 @@ const userSchema=mongoose.Schema({
     role:{
         type:String,
         required:true,
-        default:"NORMAL"
     },
     password:{
         type:String,


### PR DESCRIPTION
### Problem:
- When the server started with an empty database, all new users (including the intended admin) were assigned the "normal" role by default.
- This required manual modification of the database to set the admin user correctly.
- Even if the admin signed up first, they were still stored as a normal user.
- This led to incorrect role assignments, impacting access control on the site.

### Solution:
- Implemented logic to check if the signing-up user has a **specific predefined admin email**.
- If the email matches, the user is automatically assigned the **"admin"** role.
- All other users will continue to be assigned the **"normal"** role by default.

### Improvements:
- **No more manual database changes** needed to grant admin access.
- **Prevents unintended role assignment** and ensures admins are correctly set from the beginning.
- **Enhances security** by controlling admin role assignment at the backend.
- **Ensures persistence** across server restarts, preventing incorrect role settings in a fresh database.

### Additional Changes:
- Updated database insertion logic to dynamically assign roles during user creation.
- Ensured role persistence so admin users remain correctly assigned even after restarting the server.
- Verified that unauthorized users cannot manipulate their role through frontend requests.

### Impact:
- Admin users are correctly identified and assigned the "admin" role at the time of signup.
- Other users continue to be assigned the "normal" role without interference.
- Reduces manual intervention, making the signup process more efficient and secure.
