### PR TITLE
feat: Auto-reload pages on browser back/forward navigation

### DIFF
--- a/public/js/script1.js
+++ b/public/js/script1.js
@@ -1,0 +1,6 @@
+window.addEventListener("pageshow", function (event) {
+    if (event.persisted) {
+        // If the page is loaded from cache (back/forward navigation)
+        location.reload(); // Reload the page
+    }
+});

--- a/views/admin_homepage.ejs
+++ b/views/admin_homepage.ejs
@@ -68,7 +68,8 @@
             </form>
         </div>
     </div>
-    <script src="/js/script.js"></script>
+    <script src="/js/script.js" ></script>
+    <script src="/js/script1.js"></script>
 </body>
 
 </html>

--- a/views/admin_verify.ejs
+++ b/views/admin_verify.ejs
@@ -28,6 +28,7 @@
                     </form>
                 </div>
             </div>
+            <script src="/js/script1.js"></script>
         </body>
         </html>
         

--- a/views/allusers_info.ejs
+++ b/views/allusers_info.ejs
@@ -71,6 +71,7 @@
        
     </div>
     <script src="/js/script.js"></script>
+    <script src="/js/script1.js"></script>
 </body>
 
 </html>

--- a/views/invalid_passkey.ejs
+++ b/views/invalid_passkey.ejs
@@ -7,5 +7,6 @@
 </head>
 <body>
     <h1>Pass  key is Incorrect.You are not allowed to enter this page.</h1>
+    <script src="/js/script1.js"></script>
 </body>
 </html>

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -27,5 +27,6 @@
             </form>
         </div>
     </div>
+    <script src="/js/script1.js"></script>
 </body>
 </html>

--- a/views/normal_homepage.ejs
+++ b/views/normal_homepage.ejs
@@ -66,7 +66,8 @@
            
         </div>
     </div>
-    <script src="/js/script.js"></script>
+    <script src="/js/script.js" ></script>
+    <script src="/js/script1.js"></script>
 </body>
 
 </html>

--- a/views/not_admin.ejs
+++ b/views/not_admin.ejs
@@ -7,5 +7,6 @@
 </head>
 <body>
     <h1>You are Not a Admin</h1>
+    <script src="/js/script1.js"></script>
 </body>
 </html>

--- a/views/signup.ejs
+++ b/views/signup.ejs
@@ -31,5 +31,6 @@
             </form>
         </div>
     </div>
+    <script src="/js/script1.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### **Commit Message:**  
**feat: Auto-reload pages on browser back/forward navigation**  

### **Detailed Commit Description:**  
- Added functionality to automatically reload the page when the user navigates using the browser's **back (←) or forward (→) buttons** to prevent outdated content from being displayed.  
- Implemented this feature using the **`pageshow` event** in JavaScript, which fires whenever a page is displayed, including cases where it is loaded from cache.  
- Introduced a check using `event.persisted` to determine whether the page was loaded from the **browser’s session cache** rather than the server.  
- If `event.persisted` is `true`, the script triggers `location.reload()` to force a fresh page load, ensuring that any dynamic updates (such as **newly shortened URLs, authentication states, or admin dashboard changes**) are properly reflected.  
- This prevents users from seeing **stale or outdated data** when navigating through browser history, **improving the accuracy of displayed information and enhancing user experience**.  
- The implementation ensures that **critical updates such as new URL entries, login/logout states, and admin controls** remain up to date even when users navigate through the site using the browser’s history controls.  

This update **enhances the reliability and usability of the URL shortener by ensuring users always see the most recent content** when revisiting pages via browser navigation. 