### PR TITLE
Enhancement: Introduced "/allusersinfo" Route, Redirected Admin After V…

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const PORT=8001;
 const path=require("path");
 
 
-const staticRouter=require("./routes/staticRouter.js");
+const staticRouter=require("./routes/staticRoutes.js");
 const urlRoutes=require("./routes/url.js");
 const userRoute=require("./routes/user.js")
 const cookieparser=require("cookie-parser");


### PR DESCRIPTION
### **Commit Message**  
**Enhancement: Introduced `/allusersinfo` Route, Redirected Admin After Verification & Enforced Re-Verification on Reload**  

---

## **🔹 Previous Behavior (Before Any Changes Were Made):**  

### **Flow:**  
1. The **Admin Dashboard** button was visible only to admins. When clicked, a **GET request** was sent to the `/admin` route.  
2. The server responded by rendering `admin_verify.ejs`, which contained a form asking the admin to enter **email, password, and a unique passkey** for authentication.  
3. When the admin clicked the submit button, a **POST request** was sent to `/admin/urls`, where the provided credentials were validated.  
4. If the credentials were correct, the server **directly rendered** `allusers_info.ejs`, displaying the user details.  
5. **Browser Address Bar Issue:** Since `allusers_info.ejs` was rendered directly from the POST request, the browser **still showed `/admin/urls` instead of `/allusersinfo`**, making it unclear that the admin was viewing user details.  

### **Problems in This Approach:**  
❌ **Incorrect URL Display:** The browser showed `/admin/urls`, even though `allusers_info.ejs` was displayed.  
❌ **Direct Rendering Issue (POST Request Problem):** Since `allusers_info.ejs` was rendered **directly from a POST request**, refreshing the page triggered the **Confirm Form Resubmission** prompt. This happened because the browser attempted to **resend the previous POST request**, leading to unnecessary form re-submission and potential security concerns.  
❌ **Poor Navigation Experience:** If the admin manually typed `/allusersinfo`, it would not work because this route **did not exist yet**.  

---

## **🔹 Changes Implemented (First Major Improvement - Introducing `/allusersinfo` Route & Redirecting Admin)**  

✅ **Introduced a Dedicated `/allusersinfo` Route**  
- Instead of rendering `allusers_info.ejs` directly in the `/admin/urls` **POST request**, a new **GET route `/allusersinfo`** was created.  
- After successful authentication at `/admin/urls`, the admin is now **redirected** to `/allusersinfo` via a **GET request** instead of rendering the page directly.  
- This ensures that the **browser address bar correctly displays `/allusersinfo`**, making navigation clearer and resolving the **Confirm Form Resubmission issue**.  

### **Updated Flow After This Change:**  
1. Admin clicks the **Admin Dashboard** button → **GET request sent to `/admin`**.  
2. `admin_verify.ejs` is rendered, prompting the admin to enter **email, password, and passkey**.  
3. Admin submits the form → **POST request sent to `/admin/urls`**.  
4. Server verifies credentials and, if valid, **redirects** the admin to `/allusersinfo` (GET request).  
5. `/allusersinfo` route responds by **rendering `allusers_info.ejs`**, displaying the list of users.  

### **Problems in This Approach (After This Change):**  
❌ **Back-and-Forward Navigation Issue:**  
   - After logging in and viewing `/allusersinfo`, pressing the **back button** took the admin back to `/admin` (the verification page).  
   - Pressing the **forward button** then returned to `/allusersinfo` **without requiring re-verification**.  
   - This **was a security issue**, as it allowed access to user details without proper authentication after navigating forward.  

---

## **🔹 Fix Implemented (Second Major Improvement - Enforcing Re-Verification on Reloading `/allusersinfo`)**  

✅ **Forced Re-Verification on Reloading `/allusersinfo`**  
- When `/allusersinfo` is accessed, the system **checks if the admin is verified** using `req.session.isAdminVerified`.  
- If `req.session.isAdminVerified === false`, the admin is **redirected back to `/admin`** to enter their credentials again.  
- Once the admin successfully verifies their identity, they are redirected back to `/allusersinfo`.  
- **Before rendering `allusers_info.ejs`, `req.session.isAdminVerified` is reset to `false`** so that reloading the page requires re-authentication.  

### **Updated Flow After This Fix:**  
1. **Admin clicks the Admin Dashboard button** → **GET request sent to `/admin`**.  
2. `admin_verify.ejs` is rendered, asking for **email, password, and passkey**.  
3. Admin submits the form → **POST request sent to `/admin/urls`**.  
4. Server verifies credentials → **if valid sets `req.session.isAdminVerified === true` and Redirects admin to `/allusersinfo`** (GET request)   
5. Before rendering `allusers_info.ejs`, **`req.session.isAdminVerified` is set to `false`**.  
6. Admin sees the **user list in `allusers_info.ejs`**.  
7. **If the admin refreshes the page, `req.session.isAdminVerified === false`, so they are redirected back to `/admin`, requiring them to re-enter credentials before proceeding.**  

### **Problems in This Approach (Now Fixed):**  
✅ **Back-and-Forward Navigation Security Issue Fixed:** Now, pressing the **forward button** after navigating back requires **re-verification**, preventing unauthorized access.  
✅ **Ensured Proper Session Handling:** `req.session.isAdminVerified` is reset **before rendering `allusers_info.ejs`**, ensuring that admin verification is always required when accessing `/allusersinfo` again.  
✅ **Fixed Confirm Form Resubmission Issue:** Since the admin is **redirected** instead of rendering directly, refreshing the page no longer prompts **Confirm Form Resubmission**, improving user experience.  

---

## **🔹 Edge Cases Considered and Addressed:**  
⚡ **Scenario 1: If an admin tries to access `/allusersinfo` directly in the URL (without providing email,password and passkey in the `\admin` route)?**  
👉 The system will detect that `req.session.isAdminVerified === false` and **redirect them back to `/admin`**.  

⚡ **Scenario 2: If an admin presses the forward button after pressing back?**  
👉 They will still be required to **re-enter credentials** before seeing user details again.  

⚡ **Scenario 3: If the admin refreshes `/allusersinfo`?**  
👉 Since `req.session.isAdminVerified` is reset before rendering, they will be redirected to `/admin`, requiring **re-authentication**.  

⚡ **Scenario 4: If the admin clicks submit and a POST request is sent to `/admin` and redirected to `/allusersinfo` , what happens on refresh?**  
👉 Since the admin is **redirected** instead of rendering directly, the page reloads without triggering **Confirm Form Resubmission**.  

---

## **🔹 Final Outcome After These Changes:**  

🚀 **Introduced `/allusersinfo` as a separate route, improving URL clarity.**  
🚀 **Browser address bar now correctly displays `/allusersinfo` instead of `/admin/urls`.**  
🚀 **Fixed Confirm Form Resubmission issue by redirecting instead of rendering directly from a POST request.**  
🚀 **Back-and-forward navigation no longer bypasses authentication, improving security.**  
🚀 **Admin must re-verify credentials whenever `/allusersinfo` is accessed, preventing unauthorized access.**  
🚀 **Session-based authentication is correctly enforced, reducing the risk of unauthorized access.**  

---

### **📌 Summary of Key Fixes in This Commit:**  
✅ **Created `/allusersinfo` as a separate GET route to improve URL clarity.**  
✅ **Redirected admin to `/allusersinfo` after login instead of rendering it directly from `/admin/urls`.**  
✅ **Fixed back-and-forward button issue by enforcing re-verification when `/allusersinfo` is accessed.**  
✅ **Reset `req.session.isAdminVerified` before rendering `allusers_info.ejs` to force authentication on reload.**  
✅ **Fixed Confirm Form Resubmission issue by replacing direct POST request rendering with a redirect.**  
✅ **Improved overall security by ensuring user data is only accessible after authentication.**  

🔒 **This commit ensures that only a verified admin can access user data, and they must re-authenticate every time they visit `/allusersinfo`, preventing unauthorized access through browser navigation.** 🔒✨